### PR TITLE
Update TLS with code cleanup and project updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,25 +10,25 @@
 
 ## History
 
-### 2.5.0
+### 2.5.0 (09/13/2016)
 
 - Add options to _TLS_ with `TLSLogMessageOptions`
   - Provides support to explicitely ignore the maximum message length cap
   - Change `maximumSafeMessageLength` to truncate by default instead of discard when message length is too long and there is not delegate
 
-### 2.4.0
+### 2.4.0 (07/28/2016)
 
 - Create `TLSLoggingServiceDelegate` protocol.  Currently delegates the decision of what to do when a log message with an unsafe length is encountered.
 
-### 2.3.0
+### 2.3.0 (06/30/2016)
 
 - Add `os_log` support (iOS 10+ and macOS 10.12+) with `TLSOSLogOutputStream`
 
-### 2.2.1
+### 2.2.1 (05/31/2016)
 
 - Add cap to log message sizes.  Will also fire a notification that can be observed to identify where the message that was too large was logged from.
 
-### 2.2.0
+### 2.2.0   (05/19/2016)
 
 - Remove `TLSFileFunctionLine` struct since it is too easy to make mistakes such as constructing the struct on the stack with stack C-string values then accessing copies of the struct from other threads that should not have references to the stack C-string values. 
 

--- a/Classes/TLSConsoleOutputStreams.m
+++ b/Classes/TLSConsoleOutputStreams.m
@@ -70,38 +70,15 @@
 {
 #if OS_LOG_AVAILABLE
 
-    NSProcessInfo *procInfo = [NSProcessInfo processInfo];
-    if (![procInfo respondsToSelector:@selector(operatingSystemVersion)]) {
-        return NO;
-    }
-    NSOperatingSystemVersion osVersion = procInfo.operatingSystemVersion;
-
-#if TARGET_OS_IPHONE || TARGET_OS_TV
-
-    return osVersion.majorVersion >= 10;
-
-#elif TARGET_OS_MAC && !TARGET_OS_WATCH
-
-    if (osVersion.majorVersion < 10) {
-        // Mac OS 9
-        return NO;
-    } else if (osVersion.majorVersion > 10) {
-        // macOS 11, presumably
+#if !TARGET_OS_WATCH
+    if (@available(iOS 10, tvOS 10, macOS 10.12, *)) {
         return YES;
     }
+#endif
 
-    return osVersion.minorVersion >= 12; // 10.12+
-
-#else
-
-    (void)osVersion;
-    return NO;
-
-#endif // TARGET_OS
-
-#else // !OS_LOG_AVAILABLE
-    return NO;
 #endif // OS_LOG_AVAILABLE
+
+    return NO;
 }
 
 - (void)tls_outputLogInfo:(TLSLogMessageInfo *)logInfo

--- a/Classes/TLSDeclarations.h
+++ b/Classes/TLSDeclarations.h
@@ -37,7 +37,7 @@ FOUNDATION_EXTERN NSString * __nullable TLSCurrentThreadName(void);
 
  ## Levels to strings
 
- FOUNDATION_EXTERN NSString *TLSLogLevelToString(TLSLogLevel level) __attribute__((const));
+ FOUNDATION_EXTERN NSString *TLSLogLevelToString(TLSLogLevel level);
 
  */
 typedef NS_ENUM(NSUInteger, TLSLogLevel)
@@ -133,7 +133,7 @@ typedef NS_OPTIONS(NSInteger, TLSLogMessageOptions) {
 /** The `@__FUNCTION__` of the log message */
 @property (nonatomic, nonnull, copy, readonly) NSString *function;
 /** The `__LINE__` of the log message */
-@property (nonatomic, readonly) unsigned int line;
+@property (nonatomic, readonly) NSInteger line;
 /** The `NSString*` channel */
 @property (nonatomic, nonnull, copy, readonly) NSString *channel;
 /** The context object */
@@ -166,7 +166,17 @@ typedef NS_OPTIONS(NSInteger, TLSLogMessageOptions) {
 /**
  Designated initializer
  */
-- (nonnull instancetype)initWithLevel:(TLSLogLevel)level file:(nonnull NSString *)file function:(nonnull NSString *)function line:(unsigned int)line channel:(nonnull NSString *)channel timestamp:(nonnull NSDate *)timestamp logLifespan:(NSTimeInterval)logLifespan threadId:(unsigned int)threadId threadName:(nullable NSString *)threadName contextObject:(nullable id)contextObject message:(nonnull NSString *)message NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithLevel:(TLSLogLevel)level
+                                 file:(nonnull NSString *)file
+                             function:(nonnull NSString *)function
+                                 line:(NSInteger)line
+                              channel:(nonnull NSString *)channel
+                            timestamp:(nonnull NSDate *)timestamp
+                          logLifespan:(NSTimeInterval)logLifespan
+                             threadId:(unsigned int)threadId
+                           threadName:(nullable NSString *)threadName
+                        contextObject:(nullable id)contextObject
+                              message:(nonnull NSString *)message NS_DESIGNATED_INITIALIZER;
 
 /**
  `NS_UNAVAILABLE`

--- a/Classes/TLSDeclarations.m
+++ b/Classes/TLSDeclarations.m
@@ -31,7 +31,17 @@ NSString * const TLSErrorDomain = @"TLSErrorDomain";
     NSString *_fileFunctionLineString;
 }
 
-- (instancetype)initWithLevel:(TLSLogLevel)level file:(NSString *)file function:(NSString *)function line:(unsigned int)line channel:(NSString *)channel timestamp:(NSDate *)timestamp logLifespan:(NSTimeInterval)logLifespan threadId:(unsigned int)threadId threadName:(NSString *)threadName contextObject:(id)contextObject message:(NSString *)message
+- (instancetype)initWithLevel:(TLSLogLevel)level
+                         file:(NSString *)file
+                     function:(NSString *)function
+                         line:(NSInteger)line
+                      channel:(NSString *)channel
+                    timestamp:(NSDate *)timestamp
+                  logLifespan:(NSTimeInterval)logLifespan
+                     threadId:(unsigned int)threadId
+                   threadName:(NSString *)threadName
+                contextObject:(id)contextObject
+                      message:(NSString *)message
 {
     if (self = [super init]) {
         _level = level;
@@ -94,7 +104,7 @@ NSString * const TLSErrorDomain = @"TLSErrorDomain";
 - (NSString *)composeFileFunctionLineString
 {
     if (!_fileFunctionLineString) {
-        _fileFunctionLineString = [NSString stringWithFormat:@"(%@:%d %@)", self.file.lastPathComponent, self.line, self.function];
+        _fileFunctionLineString = [NSString stringWithFormat:@"(%@:%li %@)", self.file.lastPathComponent, (long)self.line, self.function];
     }
     return _fileFunctionLineString;
 }
@@ -103,7 +113,7 @@ NSString * const TLSErrorDomain = @"TLSErrorDomain";
 
 NSString *TLSLogLevelToString(TLSLogLevel level)
 {
-    static NSString *sLevelStrings[] = {
+    static NSString * const sLevelStrings[] = {
         @"OMG",
         @"ALR",
         @"CRI",

--- a/Classes/TLSFileOutputStream+Protected.h
+++ b/Classes/TLSFileOutputStream+Protected.h
@@ -55,7 +55,8 @@
  Create a log file directory at the designated path and set the `logFileDirectoryPath` property.
  @return NO if there is an error and _errorOut_ will be set
  */
-+ (BOOL)createLogFileDirectoryAtPath:(nonnull NSString*)logFileDirectoryPath error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
++ (BOOL)createLogFileDirectoryAtPath:(nonnull NSString*)logFileDirectoryPath
+                               error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
 
 /**
  This is the method that actually writes the formatted log message data.
@@ -73,7 +74,8 @@
  @param logFilePath must be non-nil
  @return YES if the file was opened, and NO if not.
  */
-- (BOOL)openLogFilePath:(nonnull NSString*)logFilePath error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
+- (BOOL)openLogFilePath:(nonnull NSString*)logFilePath
+                  error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
 
 #pragma mark Write Methods
 

--- a/Classes/TLSFileOutputStream.h
+++ b/Classes/TLSFileOutputStream.h
@@ -96,7 +96,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param logFileName the short file name to append as a path component to create the full logFilePath
  @param errorOut an output reference to get any errors that occur while creating the output stream.  If there is an error, the return value will be `non-nil`.
  */
-- (nullable instancetype)initWithLogFileDirectoryPath:(NSString*)logFilePath logFileName:(NSString*)logFileName error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithLogFileDirectoryPath:(NSString*)logFilePath
+                                          logFileName:(NSString*)logFileName
+                                                error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_DESIGNATED_INITIALIZER;
 
 /**
  Convenience initializer - calls the designated initializer with the `defaultLogFileDirectoryPath`
@@ -104,7 +106,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param logFileName - short name (without path). cannot be nil
  @param errorOut - address of an NSError* to contain any initialization errors
  */
-- (nullable instancetype)initWithLogFileName:(NSString*)logFileName error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
+- (nullable instancetype)initWithLogFileName:(NSString*)logFileName
+                                       error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
 
 /**
  NS_UNAVAILABLE: callers are not allowed to instantiate this class without a logFile name or path

--- a/Classes/TLSFileOutputStream.m
+++ b/Classes/TLSFileOutputStream.m
@@ -26,7 +26,9 @@ static NSString * const TLSFileOutputEventKeyNewLogFilePath = @"newLogFilePath";
 
 #pragma mark - initialization/cleanup
 
-- (instancetype)initWithLogFileDirectoryPath:(NSString*)logFileDirectoryPath logFileName:(NSString*)logFileName error:(out NSError **)errorOut
+- (instancetype)initWithLogFileDirectoryPath:(NSString*)logFileDirectoryPath
+                                 logFileName:(NSString*)logFileName
+                                       error:(out NSError **)errorOut
 {
     if (0 == [logFileDirectoryPath length]) {
         if (errorOut) {
@@ -61,7 +63,8 @@ static NSString * const TLSFileOutputEventKeyNewLogFilePath = @"newLogFilePath";
     return self;
 }
 
-- (instancetype)initWithLogFileName:(NSString*)logFileName error:(out NSError **)errorOut
+- (instancetype)initWithLogFileName:(NSString*)logFileName
+                              error:(out NSError **)errorOut
 {
     return [self initWithLogFileDirectoryPath:[TLSFileOutputStream defaultLogFileDirectoryPath]
                                   logFileName:logFileName
@@ -177,7 +180,8 @@ static NSString * const TLSFileOutputEventKeyNewLogFilePath = @"newLogFilePath";
                                         error:errorOut];
 }
 
-+ (BOOL)createLogFileDirectoryAtPath:(NSString*)logFileDirectoryPath error:(out NSError **)errorOut
++ (BOOL)createLogFileDirectoryAtPath:(NSString*)logFileDirectoryPath
+                               error:(out NSError **)errorOut
 {
     if (0 == [logFileDirectoryPath length]) {
         if (errorOut) {
@@ -225,7 +229,8 @@ static NSString * const TLSFileOutputEventKeyNewLogFilePath = @"newLogFilePath";
     return YES;
 }
 
-- (BOOL)openLogFilePath:(NSString*)logFilePath error:(NSError **)errorOut
+- (BOOL)openLogFilePath:(NSString*)logFilePath
+                  error:(NSError **)errorOut
 {
     if (0 == [logFilePath length]) {
         if (errorOut) {
@@ -244,7 +249,9 @@ static NSString * const TLSFileOutputEventKeyNewLogFilePath = @"newLogFilePath";
             NSDictionary *info = @{ TLSFileOutputEventKeyNewLogFilePath : (logFilePath) ?: [NSNull null],
                                     @"message" : @"Could not create file for logging to!",
                                     @"exceptionName" : NSObjectInaccessibleException };
-            *errorOut = [NSError errorWithDomain:NSPOSIXErrorDomain code:errCode userInfo:info];
+            *errorOut = [NSError errorWithDomain:NSPOSIXErrorDomain
+                                            code:errCode
+                                        userInfo:info];
         }
         return NO;
     }

--- a/Classes/TLSLog.h
+++ b/Classes/TLSLog.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Convenience Functions
 
 //! Convert the log level to a short parsable string
-FOUNDATION_EXTERN NSString *TLSLogLevelToString(TLSLogLevel level) __attribute__((const));
+FOUNDATION_EXTERN NSString *TLSLogLevelToString(TLSLogLevel level);
 
 //! A default application log channel if no custom channel is desired
 FOUNDATION_EXTERN NSString *TLSLogChannelApplicationDefault(void) __attribute__((const));
@@ -63,7 +63,7 @@ FOUNDATION_EXTERN void TLSLogEx(TLSLoggingService * __nullable service,
                                 NSString *channel,
                                 NSString *file,
                                 NSString *function,
-                                unsigned int line,
+                                NSInteger line,
                                 id __nullable contextObject,
                                 TLSLogMessageOptions options,
                                 NSString *format, ...) NS_FORMAT_FUNCTION(9,10);
@@ -74,7 +74,7 @@ FOUNDATION_EXTERN void TLSLogString(TLSLoggingService * __nullable service,
                                     NSString *channel,
                                     NSString *file,
                                     NSString *function,
-                                    unsigned int line,
+                                    NSInteger line,
                                     id __nullable contextObject,
                                     TLSLogMessageOptions options,
                                     NSString *message);
@@ -85,7 +85,7 @@ FOUNDATION_EXTERN void TLSvaLog(TLSLoggingService * __nullable service,
                                 NSString *channel,
                                 NSString *file,
                                 NSString *function,
-                                unsigned int line,
+                                NSInteger line,
                                 id __nullable contextObject,
                                 TLSLogMessageOptions options,
                                 NSString *format,

--- a/Classes/TLSLog.swift
+++ b/Classes/TLSLog.swift
@@ -31,13 +31,13 @@ public class TLSLog {
 
      See also: `TLSLogError`, `TLSLogWarning`, `TLSLogInformation` and `TLSLogDebug`
      */
-    public final class func log(_ level: TLSLogLevel, _ channel: String, _ context: Any?, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line)
+    public final class func log(_ level: TLSLogLevel, _ channel: String, _ context: Any?, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: Int = #line)
     {
         if (!TLSCanLog(nil, level, channel, context)) {
             return;
         }
 
-        TLSLogString(nil, level, channel, String(describing: file), String(describing: function), UInt32(line), context, TLSLogMessageOptions(), message())
+        TLSLogString(nil, level, channel, String(describing: file), String(describing: function), Int(line), context, TLSLogMessageOptions(), message())
     }
 
     /**
@@ -45,7 +45,7 @@ public class TLSLog {
 
      TLSLog.error("ChannelToLog", "This is my log message with info: \(info)")
      */
-    public final class func error(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line)
+    public final class func error(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: Int = #line)
     {
         log(TLSLogLevel.error, channel, nil /*context*/, message, file: file, function: function, line: line)
     }
@@ -55,7 +55,7 @@ public class TLSLog {
 
      TLSLog.warning("ChannelToLog", "This is my log message with info: \(info)")
      */
-    public final class func warning(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line)
+    public final class func warning(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: Int = #line)
     {
         log(TLSLogLevel.warning, channel, nil /*context*/, message, file: file, function: function, line: line)
     }
@@ -65,7 +65,7 @@ public class TLSLog {
 
      TLSLog.information("ChannelToLog", "This is my log message with info: \(info)")
      */
-    public final class func information(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line)
+    public final class func information(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: Int = #line)
     {
         log(TLSLogLevel.information, channel, nil /*context*/, message, file: file, function: function, line: line)
     }
@@ -77,7 +77,7 @@ public class TLSLog {
 
      *Note*: Only logs on `DEBUG` builds
      */
-    public final class func debug(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line)
+    public final class func debug(_ channel: String, _ message: @autoclosure () -> String, file: StaticString = #file, function: StaticString = #function, line: Int = #line)
     {
         log(TLSLogLevel.debug, channel, nil /*context*/, message, file: file, function: function, line: line)
     }

--- a/Classes/TLSLoggingService+Advanced.h
+++ b/Classes/TLSLoggingService+Advanced.h
@@ -82,7 +82,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @return past log message data from a given stream
  */
-- (nullable NSData *)retrieveLoggedDataFromOutputStream:(id<TLSOutputStream, TLSDataRetrieval>)stream maxBytes:(NSUInteger)maxBytes;
+- (nullable NSData *)retrieveLoggedDataFromOutputStream:(id<TLSOutputStream, TLSDataRetrieval>)stream
+                                               maxBytes:(NSUInteger)maxBytes;
 
 @end
 
@@ -106,7 +107,15 @@ NS_ASSUME_NONNULL_BEGIN
 
  Default == `0`, discard message
  */
-- (NSUInteger)tls_loggingService:(TLSLoggingService *)service lengthToLogForMessageExceedingMaxSafeLength:(NSUInteger)maxSafeLength level:(TLSLogLevel)level channel:(NSString *)channel file:(NSString *)file function:(NSString *)function line:(unsigned int)line contextObject:(nullable id)contextObject message:(NSString *)message;
+- (NSUInteger)tls_loggingService:(TLSLoggingService *)service
+              lengthToLogForMessageExceedingMaxSafeLength:(NSUInteger)maxSafeLength
+              level:(TLSLogLevel)level
+              channel:(NSString *)channel
+              file:(NSString *)file
+              function:(NSString *)function
+              line:(NSInteger)line
+              contextObject:(nullable id)contextObject
+              message:(NSString *)message;
 
 @end
 

--- a/Classes/TLSLoggingService.h
+++ b/Classes/TLSLoggingService.h
@@ -41,7 +41,7 @@
 /**
  Access to the shared `TLSLoggingService` singleton instance.
  */
-+ (nonnull instancetype)sharedInstance __attribute__((const));
++ (nonnull instancetype)sharedInstance;
 
 /**
  Initializer is available for any case where a distinct `TLSLoggingService` would be desired.
@@ -70,6 +70,13 @@
  @param options `TLSLogMessageOptions` to log with (default is `0`)
  @param message the `NSString` formatted message.
  */
-- (void)logWithLevel:(TLSLogLevel)level channel:(nonnull NSString *)channel file:(nonnull NSString *)file function:(nonnull NSString *)function line:(unsigned int)line contextObject:(nullable id)contextObject options:(TLSLogMessageOptions)options message:(nonnull NSString *)message, ... NS_FORMAT_FUNCTION(8,9);
+- (void)logWithLevel:(TLSLogLevel)level
+             channel:(nonnull NSString *)channel
+                file:(nonnull NSString *)file
+            function:(nonnull NSString *)function
+                line:(NSInteger)line
+       contextObject:(nullable id)contextObject
+             options:(TLSLogMessageOptions)options
+             message:(nonnull NSString *)message, ... NS_FORMAT_FUNCTION(8,9);
 
 @end

--- a/Classes/TLSProtocols.h
+++ b/Classes/TLSProtocols.h
@@ -59,7 +59,9 @@ typedef NS_OPTIONS(NSInteger, TLSFilterStatus)
 
  @warning The implementation of this method must never call a `TLSLoggingService` method nor a `TLSLog` function.  Doing so could result in unintended deadlocks.
  */
-- (TLSFilterStatus)tls_shouldFilterLevel:(TLSLogLevel)level channel:(nonnull NSString *)channel contextObject:(nullable id)contextObject;
+- (TLSFilterStatus)tls_shouldFilterLevel:(TLSLogLevel)level
+                                 channel:(nonnull NSString *)channel
+                           contextObject:(nullable id)contextObject;
 
 @end
 
@@ -129,16 +131,19 @@ typedef NSInteger TLSFileOutputEvent;
 /**
   Signal that the event has started, with information about the event
  */
-- (void)tls_fileOutputEventBegan:(TLSFileOutputEvent)event info:(nullable NSDictionary *)info;
+- (void)tls_fileOutputEventBegan:(TLSFileOutputEvent)event
+                            info:(nullable NSDictionary *)info;
 
 /**
  Signal that the event has completed successfully, with information about the event
  */
-- (void)tls_fileOutputEventFinished:(TLSFileOutputEvent)event info:(nullable NSDictionary *)info;
+- (void)tls_fileOutputEventFinished:(TLSFileOutputEvent)event
+                               info:(nullable NSDictionary *)info;
 
 /**
  Signal that the event has failed to complete successfully, with information about the event failure
  */
-- (void)tls_fileOutputEventFailed:(TLSFileOutputEvent)event info:(nullable NSDictionary *)info error:(nonnull NSError *)error;
+- (void)tls_fileOutputEventFailed:(TLSFileOutputEvent)event
+                             info:(nullable NSDictionary *)info error:(nonnull NSError *)error;
 
 @end

--- a/Classes/TLSRollingFileOutputStream.h
+++ b/Classes/TLSRollingFileOutputStream.h
@@ -85,13 +85,21 @@ typedef NS_ENUM(TLSFileOutputEvent, TLSRollingFileOutputEvent) {
  @param errorOut an output reference to get any errors that occur while creating the output stream.  If there is an error, the return value will be `nil`.
  @note *maxBytesPerLogFile* is a soft maximum.  Once that cap is exceeded, the log rolls over to the next log file.  That doesn't mean it won't exceed the max number of bytes per log file though.
  */
-- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath logFilePrefix:(nullable NSString *)logFilePrefix maxLogFiles:(NSUInteger)maxLogFiles maxBytesPerLogFile:(NSUInteger)maxBytesPerLogFile error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath
+                                        logFilePrefix:(nullable NSString *)logFilePrefix
+                                          maxLogFiles:(NSUInteger)maxLogFiles
+                                   maxBytesPerLogFile:(NSUInteger)maxBytesPerLogFile
+                                                error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_DESIGNATED_INITIALIZER;
 
 /** See initWithLogFileDirectoryPath:logFilePrefix:maxLogFiles:maxBytesPerLogFile:error: */
-- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath logFilePrefix:(nullable NSString *)logFilePrefix maxLogFiles:(NSUInteger)maxLogFiles maxBytesPerLogFile:(NSUInteger)maxBytesPerLogFile;
+- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath
+                                        logFilePrefix:(nullable NSString *)logFilePrefix
+                                          maxLogFiles:(NSUInteger)maxLogFiles
+                                   maxBytesPerLogFile:(NSUInteger)maxBytesPerLogFile;
 
 /** See initWithLogFileDirectoryPath:logFilePrefix:maxLogFiles:maxBytesPerLogFile:error: */
-- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
+- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath
+                                                error:(out NSError * __nullable __autoreleasing * __nullable)errorOut;
 
 /** See initWithLogFileDirectoryPath:logFilePrefix:maxLogFiles:maxBytesPerLogFile:error: */
 - (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString *)logFileDirectoryPath;
@@ -100,9 +108,12 @@ typedef NS_ENUM(TLSFileOutputEvent, TLSRollingFileOutputEvent) {
 - (nullable instancetype)initWithOutError:(__autoreleasing NSError * __nullable * __nullable)errorOut;
 
 /** NS_UNAVAILABLE */
-- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString*)logFilePath logFileName:(nullable NSString*)logFileName error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_UNAVAILABLE;
+- (nullable instancetype)initWithLogFileDirectoryPath:(nullable NSString*)logFilePath
+                                          logFileName:(nullable NSString*)logFileName
+                                                error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_UNAVAILABLE;
 /** NS_UNAVAILABLE */
-- (nullable instancetype)initWithLogFileName:(nullable NSString*)logFileName error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_UNAVAILABLE;
+- (nullable instancetype)initWithLogFileName:(nullable NSString*)logFileName
+                                       error:(out NSError * __nullable __autoreleasing * __nullable)errorOut NS_UNAVAILABLE;
 
 /** Unavailable because super init is NS_UNAVAILABLE */
 - (nonnull instancetype)init NS_UNAVAILABLE;

--- a/Classes/TLS_Project.h
+++ b/Classes/TLS_Project.h
@@ -48,3 +48,69 @@ FOUNDATION_EXTERN NSString *TLSGetProcessBinaryName(void);
 #define TLS_BITMASK_HAS_SUBSET_FLAGS(mask, flags)   (((mask) & (flags)) == (flags))
 /** Does the `mask` have none of the bits in `flags` set */
 #define TLS_BITMASK_EXCLUDES_FLAGS(mask, flags)     (((mask) & (flags)) == 0)
+
+#pragma mark - Private Method C Functions Support
+
+/**
+ Macro to help with implementing static C-functions instead of private methods
+
+    static NSString *_extendedDescription(PRIVATE_SELF(type))
+    {
+        if (!self) { // ALWAYS perform the `self` nil-check first
+            return nil;
+        }
+        return [[self description] stringByAppendingFormat:@" %@", self->_extendedInfo];
+    }
+
+ Can be helpful to define a macro at the top of a .m file for the primary class' `PRIVATE_SELF`.
+ Then, that macro can be used in all private function declarations/implementations
+ For example:
+
+    // in TLSLoggingService.m
+    #define SELF_ARG PRIVATE_SELF(TLSLoggingService)
+
+    static NSString *_extendedDescription(SELF_ARG)
+    {
+        if (!self) { // ALWAYS perform the `self` nil-check first
+            return nil;
+        }
+        return [[self description] stringByAppendingFormat:@" %@", self->_extendedInfo];
+    }
+
+ Calling:
+
+     // private method
+     NSString *description = [self _tip_extendedDescription];
+
+     // static function
+     NSString *description = _extendedDescription(self);
+
+ Provide context:
+
+    // Don't just pass ambiguous values to arguments, provide context
+
+    UIImage *nilOverlayImage = nil;
+    UIImage *image = _renderImage(self,
+                                  nilOverlayImage,
+                                  self.textOverlayString,
+                                  [UIColor yellow], // tintColor
+                                  UIImageOrientationUp,
+                                  CGSizeZero, // zero size to render without scaling
+                                  0, // options
+                                  NO); // opaque
+
+ Note the context is clear for each:
+
+     1. self is self, of course
+     2. nilOverlayImage: we set up a local variable so we can provide context instead of passing `nil` without context
+     3. self.textOverlayString: variable is descriptive of what it is, enough context on its own
+     4. [UIColor yellow]: it's a color, sure, but what for?  Provide a comment that it is for the `tintColor`
+     5. UIImageOrientationUp: clear that this is the orientation to provide to the render function
+     6. CGSizeZero: it's a size, but what does it mean for a special case value of zero and what's the size for?  Extra context with a descriptive comment.
+     7. 0: provides no insight, commenting that it is for `options` is sufficient at specifying that no options were selected.
+     8. NO: provides no insight, commenting that it is for `opaque` indicates the image render will be non-opaque (and probably have an alpha channel).
+ */
+
+#ifndef PRIVATE_SELF
+#define PRIVATE_SELF(type) type * __nullable const self
+#endif

--- a/ExampleLogger/ExampleAppDelegate.m
+++ b/ExampleLogger/ExampleAppDelegate.m
@@ -6,6 +6,9 @@
 //  Copyright (c) 2016 Twitter, Inc.
 //
 
+#import <TwitterLoggingService/TLSLog.h>
+#import <TwitterLoggingService/TLSLoggingService+Advanced.h>
+
 #import "ExampleAppConsoleViewController.h"
 #import "ExampleAppDelegate.h"
 #import "ExampleConfigureViewController.h"

--- a/ExampleLogger/ExampleMakeLogsViewController.m
+++ b/ExampleLogger/ExampleMakeLogsViewController.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2016 Twitter, Inc.
 //
 
+#import <TwitterLoggingService/TLSLog.h>
+
 #import "ExampleMakeLogsViewController.h"
 #import "TLSLoggingService+ExampleAdditions.h"
 

--- a/ExampleLogger/ExampleTextView.h
+++ b/ExampleLogger/ExampleTextView.h
@@ -6,7 +6,8 @@
 //  Copyright (c) 2016 Twitter, Inc.
 //
 
-@import TwitterLoggingService;
+#import <TwitterLoggingService/TwitterLoggingService.h>
+
 @import UIKit;
 
 // NOTE: for this demo, ExampleTextView will grow it's text content unbounded.  This is not a good thing in practice.

--- a/ExampleLogger/ExampleTextView.m
+++ b/ExampleLogger/ExampleTextView.m
@@ -34,7 +34,7 @@
 {
     self.text = @"";
     [[TLSLoggingService sharedInstance] dispatchAsynchronousTransaction:^{
-        _buffer = @"";
+        self->_buffer = @"";
     }];
 }
 

--- a/ExampleLogger/TLSLoggingService+ExampleAdditions.h
+++ b/ExampleLogger/TLSLoggingService+ExampleAdditions.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2016 Twitter, Inc.
 //
 
-@import TwitterLoggingService;
+#import <TwitterLoggingService/TLSLoggingService.h>
 
 FOUNDATION_EXTERN NSString * const ExampleLogChannelOne;
 FOUNDATION_EXTERN NSString * const ExampleLogChannelTwo;

--- a/README.md
+++ b/README.md
@@ -224,3 +224,13 @@ AND the given log *channel* has not been cached as a known to be an *always off*
 * `TLSCANLOGMODE=2`
 * `TLSCanLog` will base its return value on the filtering behavior of all the registered output streams
 * This will save on argument evalution but requires an expensive examination of all output streams
+
+# License
+
+Copyright 2013-2018 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0
+
+# Security Issues?
+
+Please report sensitive security issues via Twitter's bug-bounty program (https://hackerone.com/twitter) rather than GitHub.

--- a/Resources/BuildConfigurations/ExampleLogger.xcconfig
+++ b/Resources/BuildConfigurations/ExampleLogger.xcconfig
@@ -25,21 +25,18 @@
 //
 // Build Options
 
-// the following 2 settings are used for the same purpose depending upon whether
-// being build using {Xcode 7} or {Xcode 8 and beyond}
-
 // Xcode 8 and beyond
 ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
-// Xcode 7
-EMBEDDED_CONTENT_CONTAINS_SWIFT = YES
 
 
 //
 // Deployment
 
-// Continue allowing the ExampleLogger.app (linking the lib.a) to be built for iOS 6
-// even when future versions of Xcode suggest a higher default Minimum Deployment Target
-IPHONEOS_DEPLOYMENT_TARGET = 6.0
+// Continue allowing the ExampleLogger.app (linking the lib.a) to be built for iOS 7
+// (the minimum for Xcode 8, which is the oldest version Apple allows to be used for
+// submitting apps to the app store), even when future versions of Xcode default to
+// a higher minimum deployment target.
+IPHONEOS_DEPLOYMENT_TARGET = 7.0
 
 //
 // Signing

--- a/Resources/BuildConfigurations/TwitterLoggingService.framework.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingService.framework.xcconfig
@@ -35,6 +35,7 @@ APPLICATION_EXTENSION_API_ONLY = YES
 // Code Signing
 
 CODE_SIGN_IDENTITY[sdk=iphoneos*] =
+CODE_SIGN_IDENTITY[sdk=tvos*] =
 
 
 //

--- a/Resources/BuildConfigurations/TwitterLoggingService.framework.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingService.framework.xcconfig
@@ -18,26 +18,69 @@
 //
 
 //
-// use this configuration for differences from the default target settings that
-// require additional documentation
+// use this configuration for differences from the default target settings
+// for target settings that must differ between Debug configuration & Release
+// configuration, make the  specific setting change in the project.pbxproj .
+// (cf https://pewpewthespells.com/blog/xcconfig_guide.html#CondVarConfig for
+// why use of SETTING[config=Debug] does not do what we want.)
+
+
 //
+// Build Options
+
+APPLICATION_EXTENSION_API_ONLY = YES
+
+
+//
+// Code Signing
+
+CODE_SIGN_IDENTITY[sdk=iphoneos*] =
 
 
 //
 // Deployment
 
+INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+
 // Continue allowing the TwitterLoggingService.framework to be built for iOS 8
 // even when future versions of Xcode suggest a higher default Minimum Deployment Target
 IPHONEOS_DEPLOYMENT_TARGET = 8.0
 
+SKIP_INSTALL = YES
+
 
 //
 // Linking
+
+DYLIB_INSTALL_NAME_BASE = @rpath
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
 
 // necessary for ignoring undefined Crashlytics symbols that will be linked later
 OTHER_LDFLAGS = $(inherited) "-Wl,-U,_CLSLog"
 
 
 //
+// Packaging
+
+DEFINES_MODULE = YES
+INFOPLIST_FILE = ${PRODUCT_NAME}/Info.plist
+PRODUCT_BUNDLE_IDENTIFIER = com.twitter.$(PRODUCT_NAME:rfc1034identifier)
+PRODUCT_NAME = ${PROJECT_NAME}
+PUBLIC_HEADERS_FOLDER_PATH = ${PRODUCT_NAME}.framework/Headers
+
+
+//
+// Static Analyzer - Analysis Policy
+
+RUN_CLANG_STATIC_ANALYZER = $(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))
+
+
+//
 // Swift Compiler - Version
 SWIFT_VERSION = 4.0
+
+
+//
+// Versioning
+
+VERSIONING_SYSTEM = apple-generic

--- a/Resources/BuildConfigurations/TwitterLoggingService.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingService.xcconfig
@@ -1,0 +1,143 @@
+//
+//  TwitterLoggingService.xcconfig
+//  TwitterLoggingService
+//
+//  Copyright © 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//
+// use this configuration for differences from the default project settings
+// (often recommended by Xcode version upgrades).  for project settings that
+// must differ between Debug configuration & Release configuration, make the
+// specific setting change in the project.pbxproj .
+// (cf https://pewpewthespells.com/blog/xcconfig_guide.html#CondVarConfig for
+// why use of SETTING[config=Debug] does not do what we want.)
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+
+//
+// Build Options (iOS)
+
+ENABLE_BITCODE = NO
+
+
+//
+// Deployment (iOS)
+
+TARGETED_DEVICE_FAMILY = 1,2
+
+
+//
+// Linking
+
+CURRENT_PROJECT_VERSION = 2.5
+DYLIB_COMPATIBILITY_VERSION = 2
+DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
+OTHER_LDFLAGS = -ObjC
+
+//
+// Search Paths
+
+// marked "(Deprecated)" in the UI, but still defaults to YES as iOS Default
+ALWAYS_SEARCH_USER_PATHS = NO
+
+
+//
+// Apple Clang - Code Generation
+
+GCC_NO_COMMON_BLOCKS = YES
+
+
+//
+// Apple Clang - Language - C++
+
+GCC_C_LANGUAGE_STANDARD = gnu99
+
+
+//
+// Apple Clang - Language - C++
+
+CLANG_CXX_LANGUAGE_STANDARD = gnu++0x
+
+
+//
+// Apple Clang - Language - Modules
+
+CLANG_ENABLE_MODULES = YES
+
+
+//
+// Apple Clang - Language - Objective-C
+
+CLANG_ENABLE_OBJC_ARC = YES
+
+
+//
+// Apple Clang - Preprocessing
+
+ENABLE_STRICT_OBJC_MSGSEND = YES
+
+
+//
+// Apple Clang - Warnings - All Languages
+
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES
+CLANG_WARN_BOOL_CONVERSION = YES
+CLANG_WARN_COMMA = YES
+CLANG_WARN_CONSTANT_CONVERSION = YES
+CLANG_WARN_EMPTY_BODY = YES
+CLANG_WARN_ENUM_CONVERSION = YES
+CLANG_WARN_INFINITE_RECURSION = YES
+CLANG_WARN_INT_CONVERSION = YES
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES
+CLANG_WARN_STRICT_PROTOTYPES = YES
+CLANG_WARN_UNREACHABLE_CODE = YES
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+GCC_WARN_SHADOW = YES
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
+GCC_WARN_UNUSED_FUNCTION = YES
+GCC_WARN_UNUSED_VARIABLE = YES
+
+
+//
+// Apple Clang - Warnings - C++
+
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES
+CLANG_WARN_SUSPICIOUS_MOVE = YES
+
+
+//
+// Apple Clang - Warnings - Objective-C
+
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+GCC_WARN_UNDECLARED_SELECTOR = YES
+
+//
+// Apple Clang - Warnings - Objective-C and ARC
+
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
+
+
+//
+// Swift Compiler - Language
+
+SWIFT_VERSION = 4.0

--- a/Resources/BuildConfigurations/TwitterLoggingServiceLibrary.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingServiceLibrary.xcconfig
@@ -18,13 +18,49 @@
 //
 
 //
-// use this configuration for differences from the default target settings that
-// require additional documentation
+// use this configuration for differences from the default target settings,
+// for target settings that must differ between Debug configuration & Release
+// configuration, make the  specific setting change in the project.pbxproj .
+// (cf https://pewpewthespells.com/blog/xcconfig_guide.html#CondVarConfig for
+// why use of SETTING[config=Debug] does not do what we want.)
+
+
 //
+// Build Options
+
+APPLICATION_EXTENSION_API_ONLY = YES
 
 
 // Deployment
 
+DSTROOT = "/tmp/${PRODUCT_NAME}.dst"
+
 // Continue allowing the libTwitterLoggingService.a to be built for iOS 6
 // even when future versions of Xcode suggest a higher default Minimum Deployment Target
 IPHONEOS_DEPLOYMENT_TARGET = 6.0
+
+SKIP_INSTALL = YES
+
+
+//
+// Linking
+
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+//
+// Packaging
+
+PRODUCT_NAME = ${PROJECT_NAME}
+PUBLIC_HEADERS_FOLDER_PATH = include/${PRODUCT_NAME}
+
+
+//
+// Apple Clang - Language - Modules
+
+CLANG_ENABLE_MODULES = YES
+
+
+//
+// Static Analyzer - Analysis Policy
+
+RUN_CLANG_STATIC_ANALYZER = $(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))

--- a/Resources/BuildConfigurations/TwitterLoggingServiceTests.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingServiceTests.xcconfig
@@ -18,9 +18,16 @@
 //
 
 //
-// use this configuration for differences from the default target settings that
-// require additional documentation
+// use this configuration for differences from the default target settings.
+// for target settings that must differ between Debug configuration & Release
+// configuration, make the  specific setting change in the project.pbxproj .
+// (cf https://pewpewthespells.com/blog/xcconfig_guide.html#CondVarConfig for
+// why use of SETTING[config=Debug] does not do what we want.)
+
 //
+// Architectures
+
+ONLY_ACTIVE_ARCH = YES
 
 
 //
@@ -31,8 +38,8 @@
 
 // Xcode 8 and beyond
 ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
-// Xcode 7
-EMBEDDED_CONTENT_CONTAINS_SWIFT = YES
+
+DEBUG_INFORMATION_FORMAT = dwarf
 
 
 //
@@ -46,10 +53,26 @@ IPHONEOS_DEPLOYMENT_TARGET = 8.0
 //
 // Linking
 
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
 // necessary for ignoring undefined Crashlytics symbols that this Test target doesn't need
 OTHER_LDFLAGS = $(inherited) "-Wl,-U,_CLSLog"
 
 
 //
-// Swift Compiler - Version
+// Packaging
+
+INFOPLIST_FILE = ${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist
+PRODUCT_BUNDLE_IDENTIFIER = com.twitter.${PRODUCT_NAME:rfc1034identifier}
+PRODUCT_NAME = ${TARGET_NAME}
+
+//
+// Swift Compiler - General
+
+SWIFT_OBJC_BRIDGING_HEADER = ${PRODUCT_NAME}/${PRODUCT_NAME}-Bridging-Header.h
+
+
+//
+// Swift Compiler - Language
+
 SWIFT_VERSION = 4.0

--- a/Resources/BuildConfigurations/TwitterLoggingServiceTests.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingServiceTests.xcconfig
@@ -43,6 +43,12 @@ DEBUG_INFORMATION_FORMAT = dwarf
 
 
 //
+// Code Signing
+
+CODE_SIGN_IDENTITY[sdk=tvos*] =
+
+
+//
 // Deployment
 
 // Continue allowing the TwitterLoggingServiceTests (linking the .framework) to be built for iOS 8

--- a/Resources/module.modulemap
+++ b/Resources/module.modulemap
@@ -1,8 +1,54 @@
 module TwitterLoggingService {
-    umbrella header "TwitterLoggingService.h"
 
     export *
-    module * {
+
+    module TLSLog {
+        header "TLSLog.h"
+        export *
+    }
+
+    module TLSConsoleOutputStreams {
+        header "TLSConsoleOutputStreams.h"
+        export *
+    }
+
+    module TLSCrashlyticsOutputStream {
+        header "TLSCrashlyticsOutputStream.h"
+        export *
+    }
+
+    module TLSDeclarations {
+        header "TLSDeclarations.h"
+        export *
+    }
+
+    module TLSFileOutputStream {
+        header "TLSFileOutputStream.h"
+        export *
+    }
+
+    module TLSFileOutputStream_Protected {
+        header "TLSFileOutputStream+Protected.h"
+        export *
+    }
+
+    module TLSLoggingService {
+        header "TLSLoggingService.h"
+        export *
+    }
+
+    module TLSLoggingService_Advanced {
+        header "TLSLoggingService+Advanced.h"
+        export *
+    }
+
+    module TLSProtocols {
+        header "TLSProtocols.h"
+        export *
+    }
+
+    module TLSRollingFileOutputStream {
+        header "TLSRollingFileOutputStream.h"
         export *
     }
 }

--- a/TwitterLoggingService.xcodeproj/project.pbxproj
+++ b/TwitterLoggingService.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		3D82FF9C1E8DB3DC00D01B05 /* ExampleLogger.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ExampleLogger.xcconfig; sourceTree = "<group>"; };
 		3D82FF9D1E8DB3DC00D01B05 /* TwitterLoggingServiceLibrary.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TwitterLoggingServiceLibrary.xcconfig; sourceTree = "<group>"; };
 		3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TwitterLoggingService.framework.xcconfig; sourceTree = "<group>"; };
+		3DB53FC4212CDF790040C28F /* TwitterLoggingService.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TwitterLoggingService.xcconfig; sourceTree = "<group>"; };
 		3DED5FE7194698ED00EDBD9A /* TLSFileOutputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TLSFileOutputStream.h; path = Classes/TLSFileOutputStream.h; sourceTree = SOURCE_ROOT; };
 		3DED5FE8194698ED00EDBD9A /* TLSFileOutputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TLSFileOutputStream.m; path = Classes/TLSFileOutputStream.m; sourceTree = SOURCE_ROOT; };
 		8B1464A61CB6E8480068B2D2 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
@@ -244,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				3D82FF9C1E8DB3DC00D01B05 /* ExampleLogger.xcconfig */,
+				3DB53FC4212CDF790040C28F /* TwitterLoggingService.xcconfig */,
 				3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */,
 				3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */,
 				3D82FF9D1E8DB3DC00D01B05 /* TwitterLoggingServiceLibrary.xcconfig */,
@@ -570,7 +572,7 @@
 			attributes = {
 				CLASSPREFIX = TLS;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0910;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B31CCFE1858CBC6008B0BF1 = {
@@ -763,112 +765,32 @@
 /* Begin XCBuildConfiguration section */
 		8B31CD101858CBC6008B0BF1 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DB53FC4212CDF790040C28F /* TwitterLoggingService.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.5;
-				DYLIB_COMPATIBILITY_VERSION = 2;
-				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				ENABLE_BITCODE = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_SHADOW = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
-				PUBLIC_HEADERS_FOLDER_PATH = include/TwitterLoggingService;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		8B31CD111858CBC6008B0BF1 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DB53FC4212CDF790040C28F /* TwitterLoggingService.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 2.5;
-				DYLIB_COMPATIBILITY_VERSION = 2;
-				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"RELEASE=1",
 					"$(inherited)",
 				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_SHADOW = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				OTHER_LDFLAGS = "-ObjC";
-				PUBLIC_HEADERS_FOLDER_PATH = include/TwitterLoggingService;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -877,16 +799,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9D1E8DB3DC00D01B05 /* TwitterLoggingServiceLibrary.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ENABLE_MODULES = YES;
-				DSTROOT = "/tmp/${PRODUCT_NAME}.dst";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TwitterLoggingService;
-				PUBLIC_HEADERS_FOLDER_PATH = "include/${PRODUCT_NAME}";
-				RUN_CLANG_STATIC_ANALYZER = "$(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))";
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -894,15 +806,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9D1E8DB3DC00D01B05 /* TwitterLoggingServiceLibrary.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ENABLE_MODULES = YES;
-				DSTROOT = "/tmp/${PRODUCT_NAME}.dst";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TwitterLoggingService;
-				PUBLIC_HEADERS_FOLDER_PATH = "include/${PRODUCT_NAME}";
-				RUN_CLANG_STATIC_ANALYZER = "$(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))";
-				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -910,17 +813,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = TwitterLoggingServiceTests;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PRODUCT_NAME}/${PRODUCT_NAME}-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
 		};
@@ -928,17 +821,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = TwitterLoggingServiceTests;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PRODUCT_NAME}/${PRODUCT_NAME}-Bridging-Header.h";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;
 		};
@@ -981,27 +863,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = TwitterLoggingService;
-				PUBLIC_HEADERS_FOLDER_PATH = "${PRODUCT_NAME}.framework/Headers";
-				RUN_CLANG_STATIC_ANALYZER = "$(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))";
-				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -1009,25 +872,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				DEFINES_MODULE = YES;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = TwitterLoggingService;
-				PUBLIC_HEADERS_FOLDER_PATH = "${PRODUCT_NAME}.framework/Headers";
-				RUN_CLANG_STATIC_ANALYZER = "$(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))";
-				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -1035,36 +879,16 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ANALYZER_NONNULL = YES_NONAGGRESSIVE;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2.5;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 2;
-				DYLIB_CURRENT_VERSION = 2.5;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterLoggingService;
-				PRODUCT_NAME = TwitterLoggingService;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -1072,36 +896,16 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ANALYZER_NONNULL = YES_NONAGGRESSIVE;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.5;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 2;
-				DYLIB_CURRENT_VERSION = 2.5;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterLoggingService;
-				PRODUCT_NAME = TwitterLoggingService;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -1116,12 +920,9 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = N66CZ3Y3BX;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.TwitterLoggingService.OSXTwitterLoggingService-frameworkTests";
 				PRODUCT_NAME = TwitterLoggingServiceTests;
 				SDKROOT = macosx;
@@ -1140,12 +941,9 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = N66CZ3Y3BX;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.TwitterLoggingService.OSXTwitterLoggingService-frameworkTests";
 				PRODUCT_NAME = TwitterLoggingServiceTests;
 				SDKROOT = macosx;

--- a/TwitterLoggingService.xcodeproj/project.pbxproj
+++ b/TwitterLoggingService.xcodeproj/project.pbxproj
@@ -111,6 +111,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3DCA01A32136618B0004572F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B31CCE71858CBC6008B0BF1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B31CCEE1858CBC6008B0BF1;
+			remoteInfo = TwitterLoggingService;
+		};
 		8B9C928F1CEFA9C30052BA09 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8B31CCE71858CBC6008B0BF1 /* Project object */;
@@ -573,6 +580,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3DCA01A42136618B0004572F /* PBXTargetDependency */,
 			);
 			name = ExampleLogger;
 			productName = ExampleLogger;
@@ -891,6 +899,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3DCA01A42136618B0004572F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8B31CCEE1858CBC6008B0BF1 /* TwitterLoggingService */;
+			targetProxy = 3DCA01A32136618B0004572F /* PBXContainerItemProxy */;
+		};
 		8B78F2991C63A62B000194DF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B3E9D3B719CA3D2C00C43025 /* TwitterLoggingService.framework */;
@@ -1028,6 +1041,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				PRODUCT_NAME = TwitterLoggingServiceTests;
 				SDKROOT = appletvos;
@@ -1040,6 +1054,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				PRODUCT_NAME = TwitterLoggingServiceTests;
 				SDKROOT = appletvos;
@@ -1125,6 +1140,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.TwitterLoggingService.OSXTwitterLoggingService-frameworkTests";
@@ -1144,6 +1160,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.TwitterLoggingService.OSXTwitterLoggingService-frameworkTests";

--- a/TwitterLoggingService.xcodeproj/project.pbxproj
+++ b/TwitterLoggingService.xcodeproj/project.pbxproj
@@ -43,6 +43,29 @@
 		8B897D061863BF7600359106 /* TLSProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD2A1858D5F2008B0BF1 /* TLSProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BA2E94E1CA4707700ADBC8E /* TLS_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA2E94D1CA4707700ADBC8E /* TLS_Project.h */; };
 		8BA2E94F1CA4707700ADBC8E /* TLS_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA2E94D1CA4707700ADBC8E /* TLS_Project.h */; };
+		8BD0D8C72135FCD500044ED6 /* TLSLoggingSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEA3B181C73A0FF003CB57F /* TLSLoggingSwiftTests.swift */; };
+		8BD0D8C82135FCD500044ED6 /* TLSLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEA3B1B1C73A0FF003CB57F /* TLSLoggingTests.m */; };
+		8BD0D8CB2135FCD500044ED6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B31CCF21858CBC6008B0BF1 /* Foundation.framework */; };
+		8BD0D8D32135FD5300044ED6 /* TLSConsoleOutputStreams.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B31CD391858DC94008B0BF1 /* TLSConsoleOutputStreams.m */; };
+		8BD0D8D42135FD5300044ED6 /* TLSRollingFileOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B31CD2E1858DB9F008B0BF1 /* TLSRollingFileOutputStream.m */; };
+		8BD0D8D52135FD5300044ED6 /* TLSFileOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DED5FE8194698ED00EDBD9A /* TLSFileOutputStream.m */; };
+		8BD0D8D62135FD5300044ED6 /* TLSLoggingService.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B31CD1A1858CCB1008B0BF1 /* TLSLoggingService.m */; };
+		8BD0D8D72135FD5300044ED6 /* TLSCrashlyticsOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B31CD3C1858DDAA008B0BF1 /* TLSCrashlyticsOutputStream.m */; };
+		8BD0D8D82135FD5300044ED6 /* TLSDeclarations.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B31CD281858D1CF008B0BF1 /* TLSDeclarations.m */; };
+		8BD0D8D92135FD5300044ED6 /* TLSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B78F2911C6311E5000194DF /* TLSLog.swift */; };
+		8BD0D8DC2135FD5300044ED6 /* TwitterLoggingService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD1C1858CD99008B0BF1 /* TwitterLoggingService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8DD2135FD5300044ED6 /* TLSLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD241858D004008B0BF1 /* TLSLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8DE2135FD5300044ED6 /* TLSDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD271858D1CF008B0BF1 /* TLSDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8DF2135FD5300044ED6 /* TLSProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD2A1858D5F2008B0BF1 /* TLSProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E02135FD5300044ED6 /* TLSLoggingService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD191858CCB1008B0BF1 /* TLSLoggingService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E12135FD5300044ED6 /* TLSLoggingService+Advanced.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD1D1858CF3A008B0BF1 /* TLSLoggingService+Advanced.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E22135FD5300044ED6 /* TLSRollingFileOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD2D1858DB9F008B0BF1 /* TLSRollingFileOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E32135FD5300044ED6 /* TLSConsoleOutputStreams.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD381858DC94008B0BF1 /* TLSConsoleOutputStreams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E42135FD5300044ED6 /* TLS_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA2E94D1CA4707700ADBC8E /* TLS_Project.h */; };
+		8BD0D8E52135FD5300044ED6 /* TLSCrashlyticsOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD3B1858DDAA008B0BF1 /* TLSCrashlyticsOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E62135FD5300044ED6 /* TLSFileOutputStream+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5C48D2185B7755004F503A /* TLSFileOutputStream+Protected.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8E72135FD5300044ED6 /* TLSFileOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DED5FE7194698ED00EDBD9A /* TLSFileOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD0D8EF2135FDAA00044ED6 /* TwitterLoggingService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD0D8EC2135FD5300044ED6 /* TwitterLoggingService.framework */; };
 		8BEA3B231C73A560003CB57F /* TLSLoggingSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEA3B181C73A0FF003CB57F /* TLSLoggingSwiftTests.swift */; };
 		8BEA3B241C73A560003CB57F /* TLSLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEA3B1B1C73A0FF003CB57F /* TLSLoggingTests.m */; };
 		8BEA3B261C73A638003CB57F /* TwitterLoggingService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B31CD1C1858CD99008B0BF1 /* TwitterLoggingService.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -94,6 +117,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = B3E9D3B719CA3D2C00C43025;
 			remoteInfo = TwitterLoggingService.framework;
+		};
+		8BD0D8ED2135FDA200044ED6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B31CCE71858CBC6008B0BF1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8BD0D8D12135FD5300044ED6;
+			remoteInfo = "TwitterLoggingService.framework tvOS";
 		};
 		BF4A9F271EE214F1001647B5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -166,6 +196,8 @@
 		8BA2E94D1CA4707700ADBC8E /* TLS_Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TLS_Project.h; path = Classes/TLS_Project.h; sourceTree = SOURCE_ROOT; };
 		8BAE116F1CB61DC40050F16F /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = SOURCE_ROOT; };
 		8BAE11711CB623F60050F16F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
+		8BD0D8D02135FCD500044ED6 /* TwitterLoggingServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TwitterLoggingServiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BD0D8EC2135FD5300044ED6 /* TwitterLoggingService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TwitterLoggingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BEA3B181C73A0FF003CB57F /* TLSLoggingSwiftTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TLSLoggingSwiftTests.swift; path = TwitterLoggingServiceTests/TLSLoggingSwiftTests.swift; sourceTree = SOURCE_ROOT; };
 		8BEA3B191C73A0FF003CB57F /* TwitterLoggingServiceTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "TwitterLoggingServiceTests-Bridging-Header.h"; path = "TwitterLoggingServiceTests/TwitterLoggingServiceTests-Bridging-Header.h"; sourceTree = SOURCE_ROOT; };
 		8BEA3B1A1C73A0FF003CB57F /* TwitterLoggingServiceTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "TwitterLoggingServiceTests-Info.plist"; path = "TwitterLoggingServiceTests/TwitterLoggingServiceTests-Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -203,6 +235,22 @@
 				8B7DB1431869EC2600999DA0 /* CoreGraphics.framework in Frameworks */,
 				8B7DB1451869EC2600999DA0 /* UIKit.framework in Frameworks */,
 				8B7DB1411869EC2600999DA0 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BD0D8C92135FCD500044ED6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BD0D8EF2135FDAA00044ED6 /* TwitterLoggingService.framework in Frameworks */,
+				8BD0D8CB2135FCD500044ED6 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BD0D8DA2135FD5300044ED6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -277,6 +325,8 @@
 				B3E9D3B819CA3D2C00C43025 /* TwitterLoggingService.framework */,
 				BF4A9F1D1EE214F1001647B5 /* TwitterLoggingService.framework */,
 				BF4A9F251EE214F1001647B5 /* TwitterLoggingServiceTests.xctest */,
+				8BD0D8D02135FCD500044ED6 /* TwitterLoggingServiceTests.xctest */,
+				8BD0D8EC2135FD5300044ED6 /* TwitterLoggingService.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -416,6 +466,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8BD0D8DB2135FD5300044ED6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BD0D8DC2135FD5300044ED6 /* TwitterLoggingService.h in Headers */,
+				8BD0D8DD2135FD5300044ED6 /* TLSLog.h in Headers */,
+				8BD0D8DE2135FD5300044ED6 /* TLSDeclarations.h in Headers */,
+				8BD0D8DF2135FD5300044ED6 /* TLSProtocols.h in Headers */,
+				8BD0D8E02135FD5300044ED6 /* TLSLoggingService.h in Headers */,
+				8BD0D8E12135FD5300044ED6 /* TLSLoggingService+Advanced.h in Headers */,
+				8BD0D8E22135FD5300044ED6 /* TLSRollingFileOutputStream.h in Headers */,
+				8BD0D8E32135FD5300044ED6 /* TLSConsoleOutputStreams.h in Headers */,
+				8BD0D8E42135FD5300044ED6 /* TLS_Project.h in Headers */,
+				8BD0D8E52135FD5300044ED6 /* TLSCrashlyticsOutputStream.h in Headers */,
+				8BD0D8E62135FD5300044ED6 /* TLSFileOutputStream+Protected.h in Headers */,
+				8BD0D8E72135FD5300044ED6 /* TLSFileOutputStream.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B3E9D3B519CA3D2C00C43025 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -510,6 +579,42 @@
 			productReference = 8B7DB1401869EC2600999DA0 /* ExampleLogger.app */;
 			productType = "com.apple.product-type.application";
 		};
+		8BD0D8C32135FCD500044ED6 /* TwitterLoggingServiceTests tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BD0D8CD2135FCD500044ED6 /* Build configuration list for PBXNativeTarget "TwitterLoggingServiceTests tvOS" */;
+			buildPhases = (
+				8BD0D8C62135FCD500044ED6 /* Sources */,
+				8BD0D8C92135FCD500044ED6 /* Frameworks */,
+				8BD0D8CC2135FCD500044ED6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8BD0D8EE2135FDA200044ED6 /* PBXTargetDependency */,
+			);
+			name = "TwitterLoggingServiceTests tvOS";
+			productName = TwitterLoggingServiceTests;
+			productReference = 8BD0D8D02135FCD500044ED6 /* TwitterLoggingServiceTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		8BD0D8D12135FD5300044ED6 /* TwitterLoggingService.framework tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BD0D8E92135FD5300044ED6 /* Build configuration list for PBXNativeTarget "TwitterLoggingService.framework tvOS" */;
+			buildPhases = (
+				8BD0D8D22135FD5300044ED6 /* Sources */,
+				8BD0D8DA2135FD5300044ED6 /* Frameworks */,
+				8BD0D8DB2135FD5300044ED6 /* Headers */,
+				8BD0D8E82135FD5300044ED6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TwitterLoggingService.framework tvOS";
+			productName = TwitterLoggingService;
+			productReference = 8BD0D8EC2135FD5300044ED6 /* TwitterLoggingService.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		B3E9D3B719CA3D2C00C43025 /* TwitterLoggingService.framework */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B3E9D3CC19CA3D2C00C43025 /* Build configuration list for PBXNativeTarget "TwitterLoggingService.framework" */;
@@ -575,12 +680,21 @@
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
+					8B31CCEE1858CBC6008B0BF1 = {
+						ProvisioningStyle = Manual;
+					};
 					8B31CCFE1858CBC6008B0BF1 = {
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Manual;
 						TestTargetID = 8B31CCEE1858CBC6008B0BF1;
 					};
 					8B7DB13F1869EC2600999DA0 = {
+						ProvisioningStyle = Manual;
+					};
+					8BD0D8C32135FCD500044ED6 = {
+						ProvisioningStyle = Manual;
+					};
+					8BD0D8D12135FD5300044ED6 = {
 						ProvisioningStyle = Manual;
 					};
 					B3E9D3B719CA3D2C00C43025 = {
@@ -594,8 +708,7 @@
 					};
 					BF4A9F241EE214F1001647B5 = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = N66CZ3Y3BX;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -615,9 +728,11 @@
 				8B31CCEE1858CBC6008B0BF1 /* TwitterLoggingService */,
 				B3E9D3B719CA3D2C00C43025 /* TwitterLoggingService.framework */,
 				8B31CCFE1858CBC6008B0BF1 /* TwitterLoggingServiceTests */,
-				8B7DB13F1869EC2600999DA0 /* ExampleLogger */,
 				BF4A9F1C1EE214F1001647B5 /* TwitterLoggingService.framework macOS */,
 				BF4A9F241EE214F1001647B5 /* OSXTwitterLoggingServiceTests macOS */,
+				8BD0D8D12135FD5300044ED6 /* TwitterLoggingService.framework tvOS */,
+				8BD0D8C32135FCD500044ED6 /* TwitterLoggingServiceTests tvOS */,
+				8B7DB13F1869EC2600999DA0 /* ExampleLogger */,
 			);
 		};
 /* End PBXProject section */
@@ -636,6 +751,20 @@
 			files = (
 				8B7DB15C1869EC2600999DA0 /* Images.xcassets in Resources */,
 				8B7DB14B1869EC2600999DA0 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BD0D8CC2135FCD500044ED6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BD0D8E82135FD5300044ED6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,6 +828,29 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8BD0D8C62135FCD500044ED6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BD0D8C72135FCD500044ED6 /* TLSLoggingSwiftTests.swift in Sources */,
+				8BD0D8C82135FCD500044ED6 /* TLSLoggingTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BD0D8D22135FD5300044ED6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BD0D8D32135FD5300044ED6 /* TLSConsoleOutputStreams.m in Sources */,
+				8BD0D8D42135FD5300044ED6 /* TLSRollingFileOutputStream.m in Sources */,
+				8BD0D8D52135FD5300044ED6 /* TLSFileOutputStream.m in Sources */,
+				8BD0D8D62135FD5300044ED6 /* TLSLoggingService.m in Sources */,
+				8BD0D8D72135FD5300044ED6 /* TLSCrashlyticsOutputStream.m in Sources */,
+				8BD0D8D82135FD5300044ED6 /* TLSDeclarations.m in Sources */,
+				8BD0D8D92135FD5300044ED6 /* TLSLog.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B3E9D3B319CA3D2C00C43025 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -744,6 +896,11 @@
 			target = B3E9D3B719CA3D2C00C43025 /* TwitterLoggingService.framework */;
 			targetProxy = 8B9C928F1CEFA9C30052BA09 /* PBXContainerItemProxy */;
 		};
+		8BD0D8EE2135FDA200044ED6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8BD0D8D12135FD5300044ED6 /* TwitterLoggingService.framework tvOS */;
+			targetProxy = 8BD0D8ED2135FDA200044ED6 /* PBXContainerItemProxy */;
+		};
 		BF4A9F281EE214F1001647B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BF4A9F1C1EE214F1001647B5 /* TwitterLoggingService.framework macOS */;
@@ -767,7 +924,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3DB53FC4212CDF790040C28F /* TwitterLoggingService.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_TESTABILITY = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -775,8 +932,12 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -784,14 +945,19 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3DB53FC4212CDF790040C28F /* TwitterLoggingService.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"RELEASE=1",
 					"$(inherited)",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = iphoneos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -832,7 +998,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "ExampleLogger/ExampleLogger-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -859,6 +1024,51 @@
 			};
 			name = Release;
 		};
+		8BD0D8CE2135FCD500044ED6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
+				PRODUCT_NAME = TwitterLoggingServiceTests;
+				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		8BD0D8CF2135FCD500044ED6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D82FF9B1E8DB3DC00D01B05 /* TwitterLoggingServiceTests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
+				PRODUCT_NAME = TwitterLoggingServiceTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
+		8BD0D8EA2135FD5300044ED6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				PRODUCT_NAME = TwitterLoggingService;
+				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		8BD0D8EB2135FD5300044ED6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = TwitterLoggingService;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
 		B3E9D3C819CA3D2C00C43025 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
@@ -881,11 +1091,9 @@
 			buildSettings = {
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_VERSION = A;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -898,12 +1106,10 @@
 			buildSettings = {
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_VERSION = A;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 				SDKROOT = macosx;
 			};
@@ -917,12 +1123,10 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.TwitterLoggingService.OSXTwitterLoggingService-frameworkTests";
 				PRODUCT_NAME = TwitterLoggingServiceTests;
 				SDKROOT = macosx;
@@ -937,13 +1141,11 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.TwitterLoggingService.OSXTwitterLoggingService-frameworkTests";
 				PRODUCT_NAME = TwitterLoggingServiceTests;
 				SDKROOT = macosx;
@@ -985,6 +1187,24 @@
 			buildConfigurations = (
 				8B7DB1701869EC2600999DA0 /* Debug */,
 				8B7DB1711869EC2600999DA0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8BD0D8CD2135FCD500044ED6 /* Build configuration list for PBXNativeTarget "TwitterLoggingServiceTests tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8BD0D8CE2135FCD500044ED6 /* Debug */,
+				8BD0D8CF2135FCD500044ED6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8BD0D8E92135FD5300044ED6 /* Build configuration list for PBXNativeTarget "TwitterLoggingService.framework tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8BD0D8EA2135FD5300044ED6 /* Debug */,
+				8BD0D8EB2135FD5300044ED6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TwitterLoggingService.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TwitterLoggingService.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/ExampleLogger.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/ExampleLogger.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -46,7 +45,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService macOS.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService macOS.xcscheme
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
+            buildForTesting = "NO"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BF4A9F1C1EE214F1001647B5"
@@ -25,7 +25,7 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BF4A9F241EE214F1001647B5"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework tvOS.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BD0D8D12135FD5300044ED6"
+               BuildableName = "TwitterLoggingService.framework"
+               BlueprintName = "TwitterLoggingService.framework tvOS"
+               ReferencedContainer = "container:TwitterLoggingService.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BD0D8C32135FCD500044ED6"
+               BuildableName = "TwitterLoggingServiceTests.xctest"
+               BlueprintName = "TwitterLoggingServiceTests tvOS"
+               ReferencedContainer = "container:TwitterLoggingService.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BD0D8D12135FD5300044ED6"
+            BuildableName = "TwitterLoggingService.framework"
+            BlueprintName = "TwitterLoggingService.framework tvOS"
+            ReferencedContainer = "container:TwitterLoggingService.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BD0D8D12135FD5300044ED6"
+            BuildableName = "TwitterLoggingService.framework"
+            BlueprintName = "TwitterLoggingService.framework tvOS"
+            ReferencedContainer = "container:TwitterLoggingService.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BD0D8D12135FD5300044ED6"
+            BuildableName = "TwitterLoggingService.framework"
+            BlueprintName = "TwitterLoggingService.framework tvOS"
+            ReferencedContainer = "container:TwitterLoggingService.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/TwitterLoggingServiceTests/TLSLoggingSwiftTests.swift
+++ b/TwitterLoggingServiceTests/TLSLoggingSwiftTests.swift
@@ -33,73 +33,53 @@ class TLSLoggingSwiftTestMessageInfo : TLSLogMessageInfo
 {
     var didGetLevel: Bool = false
     override var level: TLSLogLevel {
-        get {
-            didGetLevel = true
-            return super.level
-        }
+        didGetLevel = true
+        return super.level
     }
     var didGetFile: Bool = false
     override var file: String {
-        get {
-            didGetFile = true
-            return super.file
-        }
+        didGetFile = true
+        return super.file
     }
     var didGetFunction: Bool = false
     override var function: String {
-        get {
-            didGetFunction = true
-            return super.function
-        }
+        didGetFunction = true
+        return super.function
     }
     var didGetLine: Bool = false
-    override var line: UInt32 {
-        get {
-            didGetLine = true
-            return super.line
-        }
+    override var line: Int {
+        didGetLine = true
+        return super.line
     }
     var didGetChannel: Bool = false
     override var channel: String {
-        get {
-            didGetChannel = true
-            return super.channel
-        }
+        didGetChannel = true
+        return super.channel
     }
     var didGetContextObject: Bool = false
     override var contextObject: Any? {
-        get {
-            didGetContextObject = true
-            return super.contextObject
-        }
+        didGetContextObject = true
+        return super.contextObject
     }
     var didGetTimestamp: Bool = false
     override var timestamp: Date {
-        get {
-            didGetTimestamp = true
-            return super.timestamp
-        }
+        didGetTimestamp = true
+        return super.timestamp
     }
     var didGetLogLifespan: Bool = false
     override var logLifespan: TimeInterval {
-        get {
-            didGetLogLifespan = true
-            return super.logLifespan
-        }
+        didGetLogLifespan = true
+        return super.logLifespan
     }
     var didGetThreadId: Bool = false
     override var threadId: UInt32 {
-        get {
-            didGetThreadId = true
-            return super.threadId
-        }
+        didGetThreadId = true
+        return super.threadId
     }
     var didGetMessage: Bool = false
     override var message: String {
-        get {
-            didGetMessage = true
-            return super.message
-        }
+        didGetMessage = true
+        return super.message
     }
 
     var didComposeFormattedMessage: Bool = false
@@ -165,7 +145,7 @@ class TLSLoggingSwiftTestCrashlyticsOutputStream : TLSCrashlyticsOutputStream
 
 class TLSLoggingSwiftTestServiceDelegate : NSObject, TLSLoggingServiceDelegate
 {
-    func tls_loggingService(_ service: TLSLoggingService, lengthToLogForMessageExceedingMaxSafeLength maxSafeLength: UInt, level: TLSLogLevel, channel: String, file: String, function: String, line: UInt32, contextObject: Any?, message: String) -> UInt {
+    func tls_loggingService(_ service: TLSLoggingService, lengthToLogForMessageExceedingMaxSafeLength maxSafeLength: UInt, level: TLSLogLevel, channel: String, file: String, function: String, line: Int, contextObject: Any?, message: String) -> UInt {
 
         DispatchQueue.main.async(execute: {
             NotificationCenter.default.post(name: .LoggingSwiftTestDiscardedMessageNotification, object: nil)
@@ -311,13 +291,13 @@ class TLSLoggingSwiftTest: XCTestCase
         // will log
         service.maximumSafeMessageLength = 0
         expectation = self.expectation(forNotification: NSNotification.Name(rawValue: Notification.Name.LoggingSwiftTestOutputStreamNotification.rawValue), object: nil, handler: nil)
-        TLSLogString(service, TLSLogLevel.error, "AnyChannel", #file, #function, UInt32(#line), nil, TLSLogMessageOptions(), longMessage)
+        TLSLogString(service, TLSLogLevel.error, "AnyChannel", #file, #function, #line, nil, TLSLogMessageOptions(), longMessage)
         self.waitForExpectations(timeout: 10, handler: nil)
 
         // won't log
         service.maximumSafeMessageLength = 16 * 1024
         expectation = self.expectation(forNotification: NSNotification.Name(rawValue: Notification.Name.LoggingSwiftTestDiscardedMessageNotification.rawValue), object: nil, handler: nil)
-        TLSLogString(service, TLSLogLevel.error, "AnyChannel", #file, #function, UInt32(#line), nil, TLSLogMessageOptions(), longMessage)
+        TLSLogString(service, TLSLogLevel.error, "AnyChannel", #file, #function, #line, nil, TLSLogMessageOptions(), longMessage)
         self.waitForExpectations(timeout: 10, handler: nil)
 
         // just to avoid the compiler warning :(


### PR DESCRIPTION
- reformatting for consistency
- xcconfig use to share settings amongst all targets, and to see comments for settings
- static functions employed (vs private methods) based on evidence of better performance