### PR TITLE
Update to v2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11.4
 script:
   ./build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 ## Info
 
-**Document version:** 2.7.0
+**Document version:** 2.7.1
 
-**Last updated:** 06/28/2019
+**Last updated:** 04/12/2020
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.7.1 (04/12/2020)
+ 
+ - Increase use of  `@autoreleasepool` to keep memory management tighter
+ - Improve at launch perf by deferring the pruning of old files for `TLSRollingFileOutputStream`
+ - Other miscellaneous bug fixes and cleanup
 
 ### 2.7.0 (06/28/2019)
 

--- a/Classes/TLSDeclarations.m
+++ b/Classes/TLSDeclarations.m
@@ -153,7 +153,7 @@ NSString * const TLSErrorDomain = @"TLSErrorDomain";
             }
 
             // LEVEL
-            if (options & TLSComposeLogMessageInfoLogChannel) {
+            if (options & TLSComposeLogMessageInfoLogLevel) {
                 [mComposedMessage appendFormat:@"[%@]", TLSLogLevelToString(level)];
             }
 

--- a/Classes/TLSLog.swift
+++ b/Classes/TLSLog.swift
@@ -41,7 +41,7 @@ public class TLSLog {
                                 line: Int = #line)
     {
         if (!TLSCanLog(nil, level, channel, context)) {
-            return;
+            return
         }
 
         TLSLogString(nil,

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ AND the given log *channel* has not been cached as a known to be an *always off*
 
 # License
 
-Copyright 2013-2018 Twitter, Inc.
+Copyright 2013-2020 Twitter, Inc.
 
 Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0
 

--- a/Resources/BuildConfigurations/TwitterLoggingService.Debug.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingService.Debug.xcconfig
@@ -2,7 +2,7 @@
 //  TwitterLoggingService.xcconfig
 //  TwitterLoggingService
 //
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -36,3 +36,15 @@
 // Arhitectures
 
 ONLY_ACTIVE_ARCH = YES
+
+//
+// Build Options
+
+// no need for dSYM when building Debug Configuration
+DEBUG_INFORMATION_FORMAT = dwarf
+
+//
+// Swift Compiler Flags - Custom Flags
+
+// when building for DEBUG, the DEBUG flag should be set
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DEBUG

--- a/Resources/BuildConfigurations/TwitterLoggingService.framework.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingService.framework.xcconfig
@@ -30,6 +30,9 @@
 
 APPLICATION_EXTENSION_API_ONLY = YES
 
+// FB7419630 - unless dwarf-with-dsym explicitly set, no dSYM will be generated for mac catalyst build
+DEBUG_INFORMATION_FORMAT[sdk=macosx*] = dwarf-with-dsym
+
 
 //
 // Deployment
@@ -48,9 +51,6 @@ SKIP_INSTALL = YES
 
 DYLIB_INSTALL_NAME_BASE = @rpath
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
-
-// necessary for ignoring undefined Crashlytics symbols that will be linked later
-OTHER_LDFLAGS = $(inherited) "-Wl,-U,_CLSLog"
 
 
 //

--- a/Resources/BuildConfigurations/TwitterLoggingService.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingService.xcconfig
@@ -2,7 +2,7 @@
 //  TwitterLoggingService.xcconfig
 //  TwitterLoggingService
 //
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/Resources/BuildConfigurations/TwitterLoggingServiceTests.xcconfig
+++ b/Resources/BuildConfigurations/TwitterLoggingServiceTests.xcconfig
@@ -61,9 +61,6 @@ IPHONEOS_DEPLOYMENT_TARGET = 8.0
 
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
 
-// necessary for ignoring undefined Crashlytics symbols that this Test target doesn't need
-OTHER_LDFLAGS = $(inherited) "-Wl,-U,_CLSLog"
-
 
 //
 // Packaging
@@ -71,6 +68,13 @@ OTHER_LDFLAGS = $(inherited) "-Wl,-U,_CLSLog"
 INFOPLIST_FILE = ${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist
 PRODUCT_BUNDLE_IDENTIFIER = com.twitter.${PRODUCT_NAME:rfc1034identifier}
 PRODUCT_NAME = ${TARGET_NAME}
+
+
+// Signing
+
+// This is the result of setting "Sign to run locally" in "Signing & Capabilities" for mac (catalyst)
+CODE_SIGN_IDENTITY[sdk=macosx*] = -
+
 
 //
 // Swift Compiler - General

--- a/TwitterLoggingService.xcodeproj/project.pbxproj
+++ b/TwitterLoggingService.xcodeproj/project.pbxproj
@@ -700,7 +700,7 @@
 			attributes = {
 				CLASSPREFIX = TLS;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B31CCEE1858CBC6008B0BF1 = {
@@ -1065,7 +1065,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D82FF9E1E8DB3DC00D01B05 /* TwitterLoggingService.framework.xcconfig */;
 			buildSettings = {
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				"DEBUG_INFORMATION_FORMAT[sdk=macosx*]" = dwarf;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -1101,7 +1101,6 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_VERSION = A;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -1139,7 +1138,6 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "${PRODUCT_NAME}/${PRODUCT_NAME}-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/ExampleLogger.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/ExampleLogger.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService macOS.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework tvOS.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework tvOS.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.framework.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "NO"

--- a/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.xcscheme
+++ b/TwitterLoggingService.xcodeproj/xcshareddata/xcschemes/TwitterLoggingService.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/TwitterLoggingServiceExt/TLSExt.h
+++ b/TwitterLoggingServiceExt/TLSExt.h
@@ -3,7 +3,7 @@
 //  TwitterLoggingService
 //
 //  Created on 6/28/19.
-//  Copyright © 2019 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/TwitterLoggingServiceExt/TLSExt.m
+++ b/TwitterLoggingServiceExt/TLSExt.m
@@ -3,7 +3,7 @@
 //  TwitterLoggingService
 //
 //  Created on 6/28/19.
-//  Copyright © 2019 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <dlfcn.h>

--- a/TwitterLoggingServiceTests/TLSLoggingSwiftTests.swift
+++ b/TwitterLoggingServiceTests/TLSLoggingSwiftTests.swift
@@ -151,8 +151,8 @@ class TLSLoggingSwiftTestServiceDelegate : NSObject, TLSLoggingServiceDelegate
 
         DispatchQueue.main.async(execute: {
             NotificationCenter.default.post(name: .LoggingSwiftTestDiscardedMessageNotification, object: nil)
-        });
-        return 0;
+        })
+        return 0
     }
 }
 
@@ -170,40 +170,41 @@ class TLSLoggingSwiftTest: XCTestCase
         super.tearDown()
     }
 
-    func expectationForLoggingLevel(_ level: TLSLogLevel) -> XCTestExpectation {
-        return self.expectation(forNotification: NSNotification.Name(rawValue: Notification.Name.LoggingSwiftTestOutputStreamNotification.rawValue), object: nil, handler: { (note: Notification) in
+    func setExpectationForLoggingLevel(_ level: TLSLogLevel)  {
+        _ = expectation(forNotification: .LoggingSwiftTestOutputStreamNotification, object: nil) { note in
             let messageInfo: TLSLogMessageInfo = note.object as! TLSLogMessageInfo
             return messageInfo.level == level
-        })
+        }
     }
 
-    func dummyLogMessageInfo(_ message: String = "Some Message") -> TLSLoggingSwiftTestMessageInfo
-    {
-        return TLSLoggingSwiftTestMessageInfo(level: TLSLogLevel.error, file:#file, function:#function ,line:#line, channel: "SomeChannel", timestamp: Date(), logLifespan: 0.1, threadId: 1, threadName: TLSCurrentThreadName(), contextObject: nil, message: message)
+    func dummyLogMessageInfo(_ message: String = "Some Message") -> TLSLoggingSwiftTestMessageInfo {
+        return TLSLoggingSwiftTestMessageInfo(level: .error, file:#file, function:#function ,line:#line, channel: "SomeChannel", timestamp: Date(), logLifespan: 0.1, threadId: 1, threadName: TLSCurrentThreadName(), contextObject: nil, message: message)
     }
 
     func testSwiftLogging() {
         let context = Date()
 
-        var expectation = self.expectationForLoggingLevel(TLSLogLevel.error)
+        setExpectationForLoggingLevel(.error)
         TLSLog.error("TestChannel", "Message with context: \(context)")
-        self.waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 10)
 
-        expectation = self.expectationForLoggingLevel(TLSLogLevel.warning)
+        setExpectationForLoggingLevel(.warning)
         TLSLog.warning("TestChannel", "Message with context: \(context)")
-        self.waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 10)
 
-        expectation = self.expectationForLoggingLevel(TLSLogLevel.information)
+        setExpectationForLoggingLevel(.information)
         TLSLog.information("TestChannel", "Message with context: \(context)")
-        self.waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 10)
 
-        expectation = self.expectationForLoggingLevel(TLSLogLevel.alert)
-        TLSLog.log(TLSLogLevel.alert, "TestChannel", context, "Message with context: \(context)")
-        self.waitForExpectations(timeout: 10, handler: nil)
+        setExpectationForLoggingLevel(.alert)
+        TLSLog.log(.alert, "TestChannel", context, "Message with context: \(context)")
+        waitForExpectations(timeout: 10)
 
-        expectation = self.expectationForLoggingLevel(TLSLogLevel.debug)
-        TLSLog.debug("TestChannel", "Message with context: \(context)")
-        self.waitForExpectations(timeout: 10, handler: nil)
+#if DEBUG
+        setExpectationForLoggingLevel(.debug)
+        TLSLog.debug("TestChannel", "Message with context: \(context)") // documentation explicitly states this only logs to debug builds
+        waitForExpectations(timeout: 10)
+#endif
 
         var delayedDate = Date()
         func delayedEvaluation() -> String {


### PR DESCRIPTION
- Increase use of  `@autoreleasepool` to keep memory management tighter
 - Improve at launch perf by deferring the pruning of old files for `TLSRollingFileOutputStream`
 - Other miscellaneous bug fixes and cleanup